### PR TITLE
send lights and sounds to sat list variables works on new blocks

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -783,7 +783,7 @@ const lights = function () {
         colour="#3399ff"
         secondaryColour="#1556E1"
         showStatusButton="false">
-            <block type="lights_sendMessage">
+            <block type="lights_sendSequence">
                 <value name="VALUE">
                     <shadow type="text">
                         <field name="TEXT">sequence</field>
@@ -792,6 +792,18 @@ const lights = function () {
                 <value name="SATELLITE">
                     <shadow type="text">
                         <field name="TEXT">Satellite #</field>
+                    </shadow>
+                </value>
+            </block>
+            <block type="lights_sendSequenceGroup">
+                <value name="VALUE">
+                    <shadow type="text">
+                        <field name="TEXT">sequence</field>
+                    </shadow>
+                </value>
+                <value name="SATELLITE_GROUP">
+                    <shadow type="text">
+                        <field name="TEXT">satellite group</field>
                     </shadow>
                 </value>
             </block>
@@ -804,6 +816,18 @@ const lights = function () {
             <value name="SATELLITE">
             <shadow type="text">
                 <field name="TEXT">satellite</field>
+            </shadow>
+            </value>
+        </block>
+            <block type="sound_playSoundFromMQTTGroup">
+            <value name="SOUND">
+            <shadow type="text">
+                <field name="TEXT">Sound</field>
+            </shadow>
+            </value>
+            <value name="SATELLITE_GROUP">
+            <shadow type="text">
+                <field name="TEXT">satellite group</field>
             </shadow>
             </value>
         </block>


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/orgs/ComputeCycles/projects/1#card-61748462

- Resolves #

### Proposed Changes

_Describe what this Pull Request does_

adds new blocks for sending out light and sound commands to groups aka lists of Sats

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
