### PR TITLE
Bvs/rollback devicecontrol rename

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -814,7 +814,7 @@ const lights = function () {
             </shadow>
         </value>
         </block>
-        <block type="deviceControl_stopEvent">
+        <block type="virtualsat_stopEvent">
             <value name="SATELLITE">
             <shadow type="text">
                 <field name="TEXT">satellite</field>
@@ -885,7 +885,7 @@ const movement = function () {
             </shadow>
         </value>
         </block>
-        <block type="deviceControl_setRadarSensitivities" id="deviceControl_setRadarSensitivities">
+        <block type="virtualsat_setRadarSensitivities" id="virtualsat_setRadarSensitivities">
         <value name="SATELLITE">
             <shadow type="text">
             <field name="TEXT">satellite</field>
@@ -922,16 +922,16 @@ const touch = function () {
     `;
 };
 
-const deviceControl = function () {
+const virtualsat = function () {
     return `
     <category
         name="Device Control"
-        id="deviceControl"
+        id="virtualSat"
         colour="#118000"
         secondaryColour="#13520A"
         showStatusButton="false">
-        <block type="deviceControl_cycleSatellitePower"></block>
-        <block type="deviceControl_rebootSatellite">
+        <block type="virtualsat_cycleSatellitePower"></block>
+        <block type="virtualsat_rebootSatellite">
         <value name="SATELLITE">
         <shadow type="text">
             <field name="TEXT">satellite</field>
@@ -995,7 +995,7 @@ const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categ
     const messagesXML = moveCategory('messages') || messages(isStage, targetId);
     const movementXML = moveCategory('movement') || movement(isStage, targetId);
     const touchXML = moveCategory('touch') || touch(isStage, targetId);
-    const deviceControlXML = moveCategory('deviceControl') || deviceControl(isStage, targetId);
+    const virtualsatXML = moveCategory('virtualsat') || virtualsat(isStage, targetId);
 
     const everything = [
         xmlOpen,
@@ -1011,7 +1011,7 @@ const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categ
         messagesXML, gap,
         movementXML, gap,
         touchXML, gap,
-        deviceControlXML, gap,
+        virtualsatXML, gap,
         variablesXML, gap,
         myBlocksXML
     ];


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/orgs/ComputeCycles/projects/1#card-62723963

- Resolves #

### Proposed Changes

_Describe what this Pull Request does_

1. changes xml names for deviceControl blocks back to virtualSat/virtualsat in all instances 

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
